### PR TITLE
v1.1 Use Load PRs to open list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ python app.py
 
 After providing your GitHub token click **Load Repos** to fetch repositories
 available to the token. Choose one from the drop-down and use **Load PRs** to
-fetch open pull requests. You can load previously merged pull requests with
-**Load Merged PRs**. Select the ones you want
+fetch open pull requests. The list of pull requests opens automatically.
+You can load previously merged pull requests with **Load Merged PRs**. Select the ones you want
 to merge or revert, then click **Merge Selected** or **Revert Selected**.
 Branches can be inspected with **Manage Branches** which opens a window
 listing branch names sorted by commit date with filtering options and a button


### PR DESCRIPTION
## Summary
- remove separate **View PR List** button
- call `PullRequestList` automatically after loading pull requests
- document the behavior change in README

## Testing
- `python -m py_compile app.py`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582994fcdc8331ab20564fd3029652