### PR TITLE
Make status label transparent v4

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,11 +37,12 @@ branch_cache = load_branch_cache()
 class BulkMerger(tk.Tk):
     def __init__(self):
         super().__init__()
-        default_font = tk.font.nametofont("TkDefaultFont")
+        default_font = font.nametofont("TkDefaultFont")
         default_font.configure(size=13)
         self.option_add("*Font", default_font)
         self.title("GitHub Bulk Merger")
         self.geometry("600x400")
+        # style for widgets will be configured after frames are created
         self.token_var = tk.StringVar()
         self.repo_var = tk.StringVar()
         self.pr_vars = []
@@ -57,6 +58,9 @@ class BulkMerger(tk.Tk):
     def create_widgets(self):
         frm = ttk.Frame(self)
         frm.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
+
+        # configure status label color to blend with the frame
+        status_bg = frm.cget("background")
 
         ttk.Label(frm, text="GitHub Token:").grid(row=0, column=0, sticky=tk.W)
         ttk.Entry(frm, textvariable=self.token_var, show="*").grid(row=0, column=1, sticky=tk.EW)
@@ -102,13 +106,25 @@ class BulkMerger(tk.Tk):
 
         self.text_output = tk.Text(frm, height=10)
         self.text_output.grid(row=5, column=0, columnspan=4, sticky=tk.EW)
-        ttk.Label(frm, textvariable=self.status_var).grid(row=6, column=0, columnspan=4, sticky=tk.W)
+        self.status_label = tk.Label(
+            frm,
+            textvariable=self.status_var,
+            bg=status_bg,
+            borderwidth=0,
+        )
+        self.status_label.grid(row=6, column=0, columnspan=4, sticky=tk.W)
         progress_frame = ttk.Frame(frm)
         progress_frame.grid(row=7, column=0, columnspan=4, sticky=tk.EW, pady=5)
         self.progress = ttk.Progressbar(progress_frame, variable=self.progress_var, maximum=100)
         self.progress.pack(fill=tk.X)
         self.progress_text = tk.StringVar(value="")
-        self.progress_label = ttk.Label(progress_frame, textvariable=self.progress_text, anchor="center")
+        self.progress_label = tk.Label(
+            progress_frame,
+            textvariable=self.progress_text,
+            anchor="center",
+            bg=progress_frame.cget("background"),
+            borderwidth=0,
+        )
         self.progress_label.place(relx=0.5, rely=0.5, anchor="center")
 
     def log(self, message):
@@ -445,7 +461,13 @@ class BranchManager(tk.Toplevel):
         progress_frame.pack(fill=tk.X, pady=5)
         self.progress = ttk.Progressbar(progress_frame, variable=self.progress_var, maximum=100)
         self.progress.pack(fill=tk.X)
-        self.progress_label = ttk.Label(progress_frame, textvariable=self.progress_text, anchor="center")
+        self.progress_label = tk.Label(
+            progress_frame,
+            textvariable=self.progress_text,
+            anchor="center",
+            bg=progress_frame.cget("background"),
+            borderwidth=0,
+        )
         self.progress_label.place(relx=0.5, rely=0.5, anchor="center")
 
     def show_context_menu(self, event):


### PR DESCRIPTION
## Summary
- fix font module usage
- make progress labels overlay the bar using transparent background

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68584343ec9c83318a30c47186bf70f3