### PR TITLE
Improve progress label transparency v3

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,11 +5,22 @@ import subprocess
 import webbrowser
 import datetime
 import tkinter as tk
-from tkinter import ttk, messagebox, font
+from tkinter import ttk, messagebox
+import tkinter.font as tkfont
 
 from github import Github
 from github.GithubException import GithubException
 import threading
+
+
+def blend_colors(widget, fg, bg, alpha=0.5):
+    """Return blended color between fg and bg with given alpha."""
+    fg_rgb = widget.winfo_rgb(fg)
+    bg_rgb = widget.winfo_rgb(bg)
+    r = int(fg_rgb[0] * alpha + bg_rgb[0] * (1 - alpha)) // 256
+    g = int(fg_rgb[1] * alpha + bg_rgb[1] * (1 - alpha)) // 256
+    b = int(fg_rgb[2] * alpha + bg_rgb[2] * (1 - alpha)) // 256
+    return f"#{r:02x}{g:02x}{b:02x}"
 
 CONFIG_FILE = "config.json"
 CACHE_DIR = "repo_cache"
@@ -37,11 +48,12 @@ branch_cache = load_branch_cache()
 class BulkMerger(tk.Tk):
     def __init__(self):
         super().__init__()
-        default_font = tk.font.nametofont("TkDefaultFont")
+        default_font = tkfont.nametofont("TkDefaultFont")
         default_font.configure(size=13)
         self.option_add("*Font", default_font)
         self.title("GitHub Bulk Merger")
         self.geometry("600x400")
+        # style for widgets will be configured after frames are created
         self.token_var = tk.StringVar()
         self.repo_var = tk.StringVar()
         self.pr_vars = []
@@ -57,6 +69,9 @@ class BulkMerger(tk.Tk):
     def create_widgets(self):
         frm = ttk.Frame(self)
         frm.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
+
+        # get window background to mimic transparency
+        status_bg = self.cget("bg")
 
         ttk.Label(frm, text="GitHub Token:").grid(row=0, column=0, sticky=tk.W)
         ttk.Entry(frm, textvariable=self.token_var, show="*").grid(row=0, column=1, sticky=tk.EW)
@@ -102,14 +117,28 @@ class BulkMerger(tk.Tk):
 
         self.text_output = tk.Text(frm, height=10)
         self.text_output.grid(row=5, column=0, columnspan=4, sticky=tk.EW)
-        ttk.Label(frm, textvariable=self.status_var).grid(row=6, column=0, columnspan=4, sticky=tk.W)
+        self.status_label = tk.Label(
+            frm,
+            textvariable=self.status_var,
+            bg=status_bg,
+            borderwidth=0,
+        )
+        self.status_label.grid(row=6, column=0, columnspan=4, sticky=tk.W)
         progress_frame = ttk.Frame(frm)
         progress_frame.grid(row=7, column=0, columnspan=4, sticky=tk.EW, pady=5)
         self.progress = ttk.Progressbar(progress_frame, variable=self.progress_var, maximum=100)
         self.progress.pack(fill=tk.X)
         self.progress_text = tk.StringVar(value="")
-        self.progress_label = ttk.Label(progress_frame, textvariable=self.progress_text, anchor="center")
+        self.progress_label = tk.Label(
+            progress_frame,
+            textvariable=self.progress_text,
+            bg=status_bg,
+            borderwidth=0,
+            anchor="center",
+        )
         self.progress_label.place(relx=0.5, rely=0.5, anchor="center")
+        faded = blend_colors(self.progress_label, self.progress_label.cget("fg"), status_bg, 0.5)
+        self.progress_label.configure(fg=faded)
 
     def log(self, message):
         self.text_output.insert(tk.END, message + "\n")
@@ -445,8 +474,17 @@ class BranchManager(tk.Toplevel):
         progress_frame.pack(fill=tk.X, pady=5)
         self.progress = ttk.Progressbar(progress_frame, variable=self.progress_var, maximum=100)
         self.progress.pack(fill=tk.X)
-        self.progress_label = ttk.Label(progress_frame, textvariable=self.progress_text, anchor="center")
+        status_bg = self.master.cget("bg")
+        self.progress_label = tk.Label(
+            progress_frame,
+            textvariable=self.progress_text,
+            bg=status_bg,
+            borderwidth=0,
+            anchor="center",
+        )
         self.progress_label.place(relx=0.5, rely=0.5, anchor="center")
+        faded = blend_colors(self.progress_label, self.progress_label.cget("fg"), status_bg, 0.5)
+        self.progress_label.configure(fg=faded)
 
     def show_context_menu(self, event):
         self.tree.focus_set()


### PR DESCRIPTION
## Summary
- add `blend_colors` helper
- fade progress text color to simulate 50% opacity

## Testing
- `python -m py_compile app.py`
- `pytest -q` *(fails: Aborted during PyQt5 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68584343ec9c83318a30c47186bf70f3