### PR TITLE
feat: improve branch loading speed v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.1.0
+Version 1.2.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert


### PR DESCRIPTION
## Summary
- bump version to 1.2.0
- parallelize branch status lookup using ThreadPoolExecutor
- update documentation version

## Testing
- `python -m py_compile app.py`
- `python app.py --help` *(fails: ModuleNotFoundError: No module named 'github')*

------
https://chatgpt.com/codex/tasks/task_e_68587384b1188331831840c10cf8d495