### PR TITLE
Add branch status cache (v1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.1.0
+Version 1.3.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert


### PR DESCRIPTION
## Summary
- cache branch statuses in branch manager
- bump version to 1.3.0

## Testing
- `pytest -q` *(fails: Aborted - likely due to missing GUI support for PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_68587384b1188331831840c10cf8d495