### PR TITLE
Fix branch cache path handling v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.3.0
+Version 1.3.1
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert

--- a/app.py
+++ b/app.py
@@ -23,10 +23,11 @@ def blend_colors(widget, fg, bg, alpha=0.5):
     b = int(fg_rgb[2] * alpha + bg_rgb[2] * (1 - alpha)) // 256
     return f"#{r:02x}{g:02x}{b:02x}"
 
-CONFIG_FILE = "config.json"
-CACHE_DIR = "repo_cache"
-BRANCH_CACHE_FILE = "branch_cache.json"
-__version__ = "1.3.0"
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(BASE_DIR, "config.json")
+CACHE_DIR = os.path.join(BASE_DIR, "repo_cache")
+BRANCH_CACHE_FILE = os.path.join(BASE_DIR, "branch_cache.json")
+__version__ = "1.3.1"
 
 
 def load_branch_cache():


### PR DESCRIPTION
## Summary
- store cache files relative to script directory
- bump version to 1.3.1

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_6859c2df312883319e81c064d0856d6b