### PR TITLE
Add GitHub links in web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.4.0
+Version 1.5.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert
@@ -49,6 +49,7 @@ python web_app.py
 ```
 
 Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser.
+The web interface lists repositories and pull requests with direct links to their GitHub pages.
 
 ## Building an executable
 

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ def blend_colors(widget, fg, bg, alpha=0.5):
 CONFIG_FILE = "config.json"
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 
 def load_branch_cache():

--- a/web_app.py
+++ b/web_app.py
@@ -8,7 +8,7 @@ from github.GithubException import GithubException
 app = Flask(__name__)
 app.secret_key = "replace-this"  # In production use env var
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
@@ -79,7 +79,10 @@ def repos():
         <h2>Select Repository</h2>
         <ul>
         {% for repo in repos %}
-          <li><a href='{{ url_for("repo", full_name=repo.full_name) }}'>{{ repo.full_name }}</a></li>
+          <li>
+            <a href='{{ url_for("repo", full_name=repo.full_name) }}'>{{ repo.full_name }}</a>
+            (<a href='{{ repo.html_url }}' target='_blank'>GitHub</a>)
+          </li>
         {% endfor %}
         </ul>
         """,
@@ -121,11 +124,14 @@ def repo(full_name):
     open_prs = list(repo.get_pulls(state="open", sort="created"))
     return render_template_string(
         """
-        <h2>Repository: {{full_name}}</h2>
+        <h2>Repository: <a href='{{ repo.html_url }}' target='_blank'>{{full_name}}</a></h2>
         <form method='post'>
         <ul>
         {% for pr in open_prs %}
-          <li><input type='checkbox' name='pr' value='{{pr.number}}'>#{{pr.number}} {{pr.title}}</li>
+          <li>
+            <input type='checkbox' name='pr' value='{{pr.number}}'>#{{pr.number}} {{pr.title}}
+            (<a href='{{ pr.html_url }}' target='_blank'>GitHub</a>)
+          </li>
         {% endfor %}
         </ul>
         <button type='submit' name='action' value='merge'>Merge Selected</button>
@@ -135,6 +141,7 @@ def repo(full_name):
         """,
         full_name=full_name,
         open_prs=open_prs,
+        repo=repo,
     )
 
 


### PR DESCRIPTION
## Summary
- link repositories and PRs to their GitHub pages in the Flask UI
- bump version to 1.5.0 and document the feature

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e53c299588331ae49b8e87a5e5b2d