### PR TITLE
Add GitHub links in web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.4.0
+Version 1.4.1
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ def blend_colors(widget, fg, bg, alpha=0.5):
 CONFIG_FILE = "config.json"
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 
 def load_branch_cache():

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,10 +1,42 @@
 import unittest
+from unittest.mock import patch, Mock
 from web_app import app
 
 class WebAppTestCase(unittest.TestCase):
     def setUp(self):
         app.config['TESTING'] = True
         self.client = app.test_client()
+
+    def test_repo_list_includes_github_links(self):
+        with patch('web_app.Github') as MockGithub:
+            g = MockGithub.return_value
+            user = g.get_user.return_value
+            repo = Mock()
+            repo.full_name = 'owner/repo'
+            repo.html_url = 'https://github.com/owner/repo'
+            user.get_repos.return_value = [repo]
+            with self.client.session_transaction() as sess:
+                sess['token'] = 'token'
+            resp = self.client.get('/repos')
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn(repo.html_url.encode(), resp.data)
+
+    def test_pr_list_includes_github_links(self):
+        with patch('web_app.Github') as MockGithub:
+            g = MockGithub.return_value
+            repo = Mock()
+            repo.full_name = 'owner/repo'
+            pr = Mock()
+            pr.number = 1
+            pr.title = 'Test'
+            pr.html_url = 'https://github.com/owner/repo/pull/1'
+            repo.get_pulls.return_value = [pr]
+            g.get_repo.return_value = repo
+            with self.client.session_transaction() as sess:
+                sess['token'] = 'token'
+            resp = self.client.get('/repo/owner/repo')
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn(pr.html_url.encode(), resp.data)
 
     def test_index_page_loads(self):
         resp = self.client.get('/')

--- a/web_app.py
+++ b/web_app.py
@@ -8,7 +8,7 @@ from github.GithubException import GithubException
 app = Flask(__name__)
 app.secret_key = "replace-this"  # In production use env var
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
@@ -79,7 +79,10 @@ def repos():
         <h2>Select Repository</h2>
         <ul>
         {% for repo in repos %}
-          <li><a href='{{ url_for("repo", full_name=repo.full_name) }}'>{{ repo.full_name }}</a></li>
+          <li>
+            <a href='{{ url_for("repo", full_name=repo.full_name) }}'>{{ repo.full_name }}</a>
+            - <a href='{{ repo.html_url }}' target='_blank'>GitHub</a>
+          </li>
         {% endfor %}
         </ul>
         """,
@@ -125,7 +128,11 @@ def repo(full_name):
         <form method='post'>
         <ul>
         {% for pr in open_prs %}
-          <li><input type='checkbox' name='pr' value='{{pr.number}}'>#{{pr.number}} {{pr.title}}</li>
+          <li>
+            <input type='checkbox' name='pr' value='{{pr.number}}'>
+            <a href='{{ pr.html_url }}' target='_blank'>#{{ pr.number }}</a>
+            {{ pr.title }}
+          </li>
         {% endfor %}
         </ul>
         <button type='submit' name='action' value='merge'>Merge Selected</button>


### PR DESCRIPTION
## Summary
- include direct GitHub links for repositories and PRs in the web UI
- bump application version to 1.4.1
- extend tests for web interface

## Testing
- `PYTHONPATH=. QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e53c299588331ae49b8e87a5e5b2d