### PR TITLE
Kamil/feature-web-token-persistence-v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ python web_app.py
 ```
 
 Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser.
+The landing page now includes a **Remember token** option that persists your GitHub token in `config.json` for future sessions.
 
 ## Building an executable
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -43,5 +43,11 @@ class WebAppTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b'GitHub Bulk Merger - Web', resp.data)
 
+    def test_token_saved_when_remember_checked(self):
+        with patch('web_app.save_token') as mock_save:
+            resp = self.client.post('/', data={'token': 'abc', 'remember': 'on'})
+            self.assertEqual(resp.status_code, 302)
+            mock_save.assert_called_once_with('abc')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow saving GitHub token from the web interface
- remember token using config.json
- test token persistence
- document the new option in the README

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e606adf748331933f7da025acfe47