### PR TITLE
Kamil/add-token-save-web-v1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.4.1
+Version 1.4.2
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert
@@ -48,7 +48,7 @@ Start the web interface with:
 python web_app.py
 ```
 
-Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser.
+Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser. The provided token is stored in `config.json` and will be reused on subsequent visits.
 
 ## Building an executable
 

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ def blend_colors(widget, fg, bg, alpha=0.5):
 CONFIG_FILE = "config.json"
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 
 def load_branch_cache():

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -43,5 +43,12 @@ class WebAppTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b'GitHub Bulk Merger - Web', resp.data)
 
+    def test_token_saved_to_config(self):
+        with patch('web_app.CONFIG_FILE', 'tmp_config.json'):
+            with patch('web_app.save_config') as mock_save:
+                resp = self.client.post('/', data={'token': 't'}, follow_redirects=False)
+                self.assertEqual(resp.status_code, 302)
+                mock_save.assert_called_with('t')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- persist API token in the web interface
- update documentation for web token saving
- bump version numbers to 1.4.2
- test token storage logic

## Testing
- `PYTHONPATH=. pytest -q tests/test_web_app.py::WebAppTestCase::test_token_saved_to_config`
- `PYTHONPATH=. pytest -q` *(fails: PyQt5 requires display)*

------
https://chatgpt.com/codex/tasks/task_e_685e606adf748331933f7da025acfe47