### PR TITLE
Kamil/feature-token-dropdown-v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ python web_app.py
 ```
 
 Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser.
+The landing page now includes a **Remember token** option that persists tokens in `config.json`. Saved tokens can be selected from a drop-down list.
 
 ## Building an executable
 


### PR DESCRIPTION
## Summary
- allow multiple GitHub tokens to be stored in `config.json`
- display saved tokens in a drop-down on the landing page
- update README for new selection option
- test token list rendering and selection

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e606adf748331933f7da025acfe47