### PR TITLE
Add drag and key multi-select for PR checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.4.1
+Version 1.5.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ def blend_colors(widget, fg, bg, alpha=0.5):
 CONFIG_FILE = "config.json"
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 
 def load_branch_cache():

--- a/web_app.py
+++ b/web_app.py
@@ -16,7 +16,7 @@ from github.GithubException import GithubException
 app = Flask(__name__)
 app.secret_key = "replace-this"  # In production use env var
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
@@ -178,7 +178,7 @@ def repo(full_name):
         <ul>
         {% for pr in open_prs %}
           <li>
-            <input type='checkbox' name='pr' value='{{pr.number}}'>
+            <input type='checkbox' class='pr-checkbox' name='pr' value='{{pr.number}}'>
             <a href='{{ pr.html_url }}' target='_blank'>#{{ pr.number }}</a>
             {{ pr.title }}
           </li>
@@ -188,6 +188,44 @@ def repo(full_name):
         <button type='submit' name='action' value='revert'>Revert Selected</button>
         <button type='submit' name='action' value='close'>Close Selected</button>
         </form>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+          const boxes = Array.from(document.querySelectorAll('.pr-checkbox'));
+          let last = null;
+          let dragging = false;
+          let dragState = false;
+
+          boxes.forEach((box, idx) => {
+            box.dataset.index = idx;
+            box.addEventListener('mousedown', e => {
+              dragging = true;
+              dragState = !box.checked;
+              box.checked = dragState;
+              last = idx;
+              e.preventDefault();
+            });
+            box.addEventListener('mouseover', () => {
+              if (dragging) {
+                box.checked = dragState;
+              }
+            });
+            box.addEventListener('mouseup', () => { dragging = false; });
+            box.addEventListener('click', e => {
+              if (e.shiftKey && last !== null) {
+                const start = Math.min(last, idx);
+                const end = Math.max(last, idx);
+                for (let i = start; i <= end; i++) {
+                  boxes[i].checked = box.checked;
+                }
+              }
+              if (!e.ctrlKey) {
+                last = idx;
+              }
+            });
+          });
+          document.addEventListener('mouseup', () => { dragging = false; });
+        });
+        </script>
         """,
         full_name=full_name,
         open_prs=open_prs,


### PR DESCRIPTION
## Summary
- enable range selection and drag multi-select in web app
- bump version to 1.5.0

## Testing
- `PYTHONPATH=. pytest tests/test_web_app.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6e99510483318440accc9708f16a