### PR TITLE
Add branch manager to web interface v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.5.0
+Version 1.6.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert
@@ -32,7 +32,8 @@ You can load previously merged pull requests with **Load Merged PRs**. Select th
 to merge or revert, then click **Merge Selected** or **Revert Selected**.
 Branches can be inspected with **Manage Branches** which opens a window
 listing branch names sorted by commit date with filtering options and a button
-to delete checked branches.
+to delete checked branches. The web interface offers a similar manager from each
+repository page allowing deletion of selected branches.
 The main window displays a status line showing progress when loading
 repositories, pull requests or branches. Branch lists are cached per repository
 to avoid fetching them repeatedly.
@@ -49,7 +50,7 @@ python web_app.py
 ```
 
 Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser.
-The landing page now includes a **Remember token** option that persists tokens in `config.json`. Saved tokens can be selected from a drop-down list.
+The landing page now includes a **Remember token** option that persists tokens in `config.json`. Saved tokens can be selected from a drop-down list. Repository pages provide a link to **Manage Branches** for deleting selected branches.
 
 ## Building an executable
 

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ def blend_colors(widget, fg, bg, alpha=0.5):
 CONFIG_FILE = "config.json"
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 
 def load_branch_cache():


### PR DESCRIPTION
## Summary
- implement branch deletion in web app
- expose branch manager link on repository page
- update README documentation
- bump version to 1.6.0
- extend tests for new routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e768a534c8331b0ef3b56a8907913