### PR TITLE
Add branch manager to web interface v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.5.0
+Version 1.6.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert
@@ -50,6 +50,7 @@ python web_app.py
 
 Open `http://127.0.0.1:5000/` in your browser and follow the instructions to merge or revert pull requests using the browser.
 The landing page now includes a **Remember token** option that persists tokens in `config.json`. Saved tokens can be selected from a drop-down list.
+You can manage and delete branches from the new **Manage Branches** page linked from each repository view.
 
 ## Building an executable
 


### PR DESCRIPTION
## Summary
- extend web interface with branch management
- allow deleting branches
- link branch manager from repository view
- bump version to 1.6.0 and update docs
- cover new feature with tests

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e768a534c8331b0ef3b56a8907913