### PR TITLE
Add sortable PR table to web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.6.0
+Version 1.7.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert


### PR DESCRIPTION
## Summary
- present pull requests in a table and show creation date
- enable sorting by clicking the **Date** header
- bump web version to 1.7.0

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7b9eefb4833185c73762b8e6d429