### PR TITLE
Implement streaming progress bar for web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Open `http://127.0.0.1:5000/` in your browser and follow the instructions to mer
 The landing page now includes a **Remember token** option that persists tokens in `config.json`. Saved tokens can be selected from a drop-down list.
 You can manage and delete branches from the new **Manage Branches** page linked from each repository view.
 The branch management view now also supports range selection and drag selection similar to the pull request list.
+Loading repositories and pull requests now displays a progress bar with the current percentage and status.
 
 ## Building an executable
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -17,7 +17,7 @@ class WebAppTestCase(unittest.TestCase):
             user.get_repos.return_value = [repo]
             with self.client.session_transaction() as sess:
                 sess['token'] = 'token'
-            resp = self.client.get('/repos')
+            resp = self.client.get('/repos_stream')
             self.assertEqual(resp.status_code, 200)
             self.assertIn(repo.html_url.encode(), resp.data)
 
@@ -34,7 +34,7 @@ class WebAppTestCase(unittest.TestCase):
             g.get_repo.return_value = repo
             with self.client.session_transaction() as sess:
                 sess['token'] = 'token'
-            resp = self.client.get('/repo/owner/repo')
+            resp = self.client.get('/repo/owner/repo/prs_stream')
             self.assertEqual(resp.status_code, 200)
             self.assertIn(pr.html_url.encode(), resp.data)
 


### PR DESCRIPTION
## Summary
- add /repos_stream and /repo/<repo>/prs_stream endpoints for Server-Sent Events
- inject progress bar UI for repository and PR pages
- update tests for the new streaming routes
- document progress bar in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f548ec4588331af7d06dff65f3410