### PR TITLE
Add streaming progress to web repository loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.7.1
+Version 1.8.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert
@@ -52,6 +52,8 @@ Open `http://127.0.0.1:5000/` in your browser and follow the instructions to mer
 The landing page now includes a **Remember token** option that persists tokens in `config.json`. Saved tokens can be selected from a drop-down list.
 You can manage and delete branches from the new **Manage Branches** page linked from each repository view.
 The branch management view now also supports range selection and drag selection similar to the pull request list.
+
+New in **1.8.0**, the `/repos_async` page streams repository names as they are fetched and displays a progress bar showing percentage completion and current status.
 
 ## Building an executable
 


### PR DESCRIPTION
## Summary
- provide `/repos_async` page with visual progress bar
- stream repository names via `/repos_stream` using Server-Sent Events
- document the new asynchronous workflow in the README

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f548ec4588331af7d06dff65f3410