### PR TITLE
Add status column to PR table

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -29,6 +29,8 @@ class WebAppTestCase(unittest.TestCase):
             pr = Mock()
             pr.number = 1
             pr.title = 'Test'
+            pr.state = 'open'
+            pr.merged = False
             pr.html_url = 'https://github.com/owner/repo/pull/1'
             repo.get_pulls.return_value = [pr]
             g.get_repo.return_value = repo
@@ -37,6 +39,8 @@ class WebAppTestCase(unittest.TestCase):
             resp = self.client.get('/repo/owner/repo')
             self.assertEqual(resp.status_code, 200)
             self.assertIn(pr.html_url.encode(), resp.data)
+            self.assertIn(b'Status', resp.data)
+            self.assertIn(b'open', resp.data)
 
     def test_index_page_loads(self):
         resp = self.client.get('/')

--- a/web_app.py
+++ b/web_app.py
@@ -239,30 +239,32 @@ def repo(full_name):
             for pr in prs:
                 pr.edit(state="closed")
         flash("Action completed")
-    open_prs = list(repo.get_pulls(state="open", sort="created"))
+    prs = list(repo.get_pulls(state="all", sort="created"))
     return render_template_string(
         NAV_TEMPLATE + """
         <h2>Repository: {{full_name}}</h2>
         <form method='post'>
         <table id='pr-table'>
-          <thead>
-            <tr>
-              <th></th>
-              <th>Title</th>
-              <th id='date-header' data-order='asc'>Date</th>
-              <th>PR</th>
-            </tr>
-          </thead>
-          <tbody>
-          {% for pr in open_prs %}
-            <tr class='pr-row'>
-              <td><input type='checkbox' class='pr-checkbox' name='pr' value='{{pr.number}}'></td>
-              <td>{{ pr.title }}</td>
-              <td data-sort='{{ pr.created_at.isoformat() }}'>{{ pr.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
-              <td><a href='{{ pr.html_url }}' target='_blank'>#{{ pr.number }}</a></td>
-            </tr>
-          {% endfor %}
-          </tbody>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Title</th>
+                <th id='date-header' data-order='asc'>Date</th>
+                <th>Status</th>
+                <th>PR</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for pr in prs %}
+              <tr class='pr-row'>
+                <td><input type='checkbox' class='pr-checkbox' name='pr' value='{{pr.number}}'></td>
+                <td>{{ pr.title }}</td>
+                <td data-sort='{{ pr.created_at.isoformat() }}'>{{ pr.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                <td>{{ 'merged' if pr.merged else pr.state }}</td>
+                <td><a href='{{ pr.html_url }}' target='_blank'>#{{ pr.number }}</a></td>
+              </tr>
+            {% endfor %}
+            </tbody>
         </table>
         <button type='submit' name='action' value='merge'>Merge Selected</button>
         <button type='submit' name='action' value='revert'>Revert Selected</button>
@@ -327,7 +329,7 @@ def repo(full_name):
         </script>
         """,
         full_name=full_name,
-        open_prs=open_prs,
+        prs=prs,
         repo_name=full_name,
     )
 


### PR DESCRIPTION
## Summary
- display pull request status in the web UI list
- update tests for the new column

## Testing
- `pip install PyGithub GitPython Flask PyQt5`
- `QT_QPA_PLATFORM=offscreen python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601dc4b53c83318a2d8a4bc80c7469