### PR TITLE
Kamil/add-status-column-v1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.7.1
+Version 1.8.1
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch, Mock
+import datetime
 from web_app import app
 
 class WebAppTestCase(unittest.TestCase):
@@ -31,6 +32,9 @@ class WebAppTestCase(unittest.TestCase):
             pr.number = 1
             pr.title = 'Test'
             pr.html_url = 'https://github.com/owner/repo/pull/1'
+            pr.created_at = datetime.datetime.now()
+            pr.state = 'open'
+            pr.merged = False
             repo.get_pulls.return_value = [pr]
             g.get_repo.return_value = repo
             with self.client.session_transaction() as sess:
@@ -39,6 +43,7 @@ class WebAppTestCase(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
             data = resp.get_json()
             self.assertEqual(data['pulls'][0]['html_url'], pr.html_url)
+            self.assertEqual(data['pulls'][0]['status'], 'open')
 
     def test_index_page_loads(self):
         resp = self.client.get('/')

--- a/web_app.py
+++ b/web_app.py
@@ -16,7 +16,7 @@ from github.GithubException import GithubException
 app = Flask(__name__)
 app.secret_key = "replace-this"  # In production use env var
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
@@ -209,7 +209,7 @@ def api_pulls(full_name: str) -> dict:
         return {"error": "unauthorized"}, 401
     g = Github(token, per_page=100)
     repo = g.get_repo(full_name)
-    pulls = repo.get_pulls(state="open", sort="created")
+    pulls = repo.get_pulls(state="all", sort="created")
     return {
         "pulls": [
             {
@@ -217,6 +217,7 @@ def api_pulls(full_name: str) -> dict:
                 "title": pr.title,
                 "html_url": pr.html_url,
                 "created_at": pr.created_at.isoformat(),
+                "status": "merged" if pr.merged else pr.state,
             }
             for pr in pulls
         ]
@@ -337,6 +338,7 @@ def repo(full_name):
               <th></th>
               <th>Title</th>
               <th id='date-header' data-order='asc'>Date</th>
+              <th>Status</th>
               <th>PR</th>
             </tr>
           </thead>
@@ -416,6 +418,7 @@ def repo(full_name):
                 tr.innerHTML = `<td><input type='checkbox' class='pr-checkbox' name='pr' value='${pr.number}'></td>` +
                                `<td>${pr.title}</td>` +
                                `<td data-sort='${pr.created_at}'>${pr.created_at.slice(0,16).replace('T',' ')}</td>` +
+                               `<td>${pr.status}</td>` +
                                `<td><a href='${pr.html_url}' target='_blank'>#${pr.number}</a></td>`;
                 tbody.appendChild(tr);
                 const pct = Math.round(((idx + 1) / data.pulls.length) * 100);


### PR DESCRIPTION
## Summary
- show pull request status on the web interface
- expose status field from `/api/pulls`
- update tests

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860266d24b48331a8ceb25cdbfd64a7