### PR TITLE
Add real-time list refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Bulk Merger
 
-Version 1.7.1
+Version 1.9.0
 
 This repository contains a small GUI tool written in Python that allows you to
 select multiple pull requests from a repository and merge them in bulk or revert

--- a/web_app.py
+++ b/web_app.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock
 app = Flask(__name__)
 app.secret_key = "replace-this"  # In production use env var
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 CACHE_DIR = "repo_cache"
 BRANCH_CACHE_FILE = "branch_cache.json"
@@ -261,6 +261,29 @@ def api_pulls(full_name: str) -> dict:
     }
 
 
+@app.route("/api/branches/<path:full_name>")
+def api_branches(full_name: str) -> dict:
+    token = session.get("token")
+    if not token:
+        return {"error": "unauthorized"}, 401
+    g = Github(token, per_page=100)
+    repo = g.get_repo(full_name)
+    branches = list(repo.get_branches())
+    cfg = load_config()
+    protected = cfg.get("protected_branches", {}).get(full_name, [])
+    return {
+        "branches": [
+            {
+                "name": br.name,
+                "commit_date": br.commit.commit.author.date.isoformat(),
+                "url": f"https://github.com/{full_name}/tree/{br.name}",
+                "protected": br.name in protected,
+            }
+            for br in branches
+        ]
+    }
+
+
 @app.route("/", methods=["GET", "POST"])
 def index():
     cfg = load_config()
@@ -441,7 +464,7 @@ def repo(full_name):
           });
         }
 
-        document.addEventListener('DOMContentLoaded', function() {
+        function loadPRs() {
           updateProgress(0, 'Loading pull requests');
           fetch('{{ url_for('api_pulls', full_name=full_name) }}')
             .then(r => r.json())
@@ -463,6 +486,11 @@ def repo(full_name):
               updateProgress(100, 'Ready');
             })
             .catch(() => { updateProgress(100, 'Error'); });
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+          loadPRs();
+          setInterval(loadPRs, 30000);
         });
         </script>
         """,
@@ -537,7 +565,7 @@ def branches(full_name):
         </form>
         <p><a href='{{ url_for("repo", full_name=full_name) }}'>Back</a></p>
         <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        function initBranchInteractions() {
           const rows = Array.from(document.querySelectorAll('.branch-row'));
           const boxes = rows.map(r => r.querySelector('.branch-checkbox'));
           let last = null;
@@ -590,6 +618,36 @@ def branches(full_name):
             newRows.forEach(r => tbody.appendChild(r));
             dateHeader.dataset.order = asc ? 'asc' : 'desc';
           });
+        }
+
+        function loadBranches() {
+          updateProgress(0, 'Loading branches');
+          fetch('{{ url_for('api_branches', full_name=full_name) }}')
+            .then(r => r.json())
+            .then(data => {
+              const tbody = document.querySelector('#branch-table tbody');
+              tbody.innerHTML = '';
+              data.branches.forEach((br, idx) => {
+                const tr = document.createElement('tr');
+                tr.className = 'branch-row';
+                tr.innerHTML = `<td><input type='checkbox' class='branch-checkbox' name='branch' value='${br.name}'></td>` +
+                               `<td>${br.name}</td>` +
+                               `<td data-sort='${br.commit_date}'>${br.commit_date.slice(0,16).replace('T',' ')}</td>` +
+                               `<td><a href='${br.url}' target='_blank'>${br.name}</a></td>` +
+                               `<td><form method='post' style='display:inline'><button name='toggle_protect' value='${br.name}' style='background:none;border:none'>${br.protected ? '★' : '☆'}</button></form></td>`;
+                tbody.appendChild(tr);
+                const pct = Math.round(((idx + 1) / data.branches.length) * 100);
+                updateProgress(pct, 'Loading branches');
+              });
+              initBranchInteractions();
+              updateProgress(100, 'Ready');
+            })
+            .catch(() => { updateProgress(100, 'Error'); });
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+          loadBranches();
+          setInterval(loadBranches, 30000);
         });
         </script>
         """,


### PR DESCRIPTION
## Summary
- add periodic refresh of PR and branch lists
- expose new API endpoint for branches
- bump web version to 1.9.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ceabd5f3083319641834e192a351e