### PR TITLE
Implement parallel branch requests v1.0.1

### DIFF
--- a/app.py
+++ b/app.py
@@ -624,16 +624,25 @@ class BranchManager(tk.Toplevel):
             else:
                 g = Github(self.token, per_page=100)
                 repo = g.get_repo(self.repo_name)
-                branches_list = repo.get_branches()
+                branches_list = list(repo.get_branches())
                 branches = []
-                total = getattr(branches_list, "totalCount", None)
-                for idx, br in enumerate(branches_list):
+                total = getattr(branches_list, "totalCount", None) or len(branches_list)
+
+                def fetch_branch_data(br):
                     dt = br.commit.commit.author.date
-                    branches.append((br.name, dt))
-                    self.after(0, lambda n=br.name, d=dt: self._add_branch(n, d, "loading"))
-                    if total:
-                        progress = ((idx + 1) / (total * 2)) * 100
-                        self.after(0, lambda p=progress: self.set_progress(p))
+                    return br.name, dt
+
+                completed = 0
+                with ThreadPoolExecutor(max_workers=5) as executor:
+                    futures = {executor.submit(fetch_branch_data, br): br for br in branches_list}
+                    for future in as_completed(futures):
+                        name, dt = future.result()
+                        branches.append((name, dt))
+                        self.after(0, lambda n=name, d=dt: self._add_branch(n, d, "loading"))
+                        completed += 1
+                        if total:
+                            progress = (completed / (total * 2)) * 100
+                            self.after(0, lambda p=progress: self.set_progress(p))
                 branch_cache[self.repo_name] = [(b, d.isoformat()) for b, d in branches]
                 save_branch_cache(branch_cache)
 

--- a/web_app.py
+++ b/web_app.py
@@ -13,6 +13,7 @@ from flask import (
 from github import Github
 from github.GithubException import GithubException
 from unittest.mock import Mock
+from concurrent.futures import ThreadPoolExecutor
 
 app = Flask(__name__)
 app.secret_key = "replace-this"  # In production use env var
@@ -270,9 +271,9 @@ def api_branches(full_name: str) -> dict:
     repo = g.get_repo(full_name)
     cfg = load_config()
     protected = cfg.get("protected_branches", {}).get(full_name, [])
-    branches = repo.get_branches()
-    data = []
-    for br in branches:
+    branches = list(repo.get_branches())
+
+    def process_branch(br):
         date = None
         if hasattr(br, "commit") and hasattr(br.commit, "commit"):
             author = getattr(br.commit.commit, "author", None)
@@ -281,14 +282,15 @@ def api_branches(full_name: str) -> dict:
                     date = author.date.isoformat()
                 except Exception:
                     date = str(author.date)
-        data.append(
-            {
-                "name": br.name,
-                "date": date or "",
-                "html_url": f"https://github.com/{full_name}/tree/{br.name}",
-                "protected": br.name in protected,
-            }
-        )
+        return {
+            "name": br.name,
+            "date": date or "",
+            "html_url": f"https://github.com/{full_name}/tree/{br.name}",
+            "protected": br.name in protected,
+        }
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        data = list(executor.map(process_branch, branches))
     return {"branches": data}
 
 


### PR DESCRIPTION
## Summary
- parallelize branch date retrieval in desktop app
- speed up `/api/branches` using `ThreadPoolExecutor`

## Testing
- `PYTHONPATH=$PWD QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0deae8bc83318b89ee9e342aaac5