### PR TITLE
Add dark mode support

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -45,6 +45,11 @@ class WebAppTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b'GitHub Bulk Merger - Web', resp.data)
 
+    def test_index_includes_dark_mode_toggle(self):
+        resp = self.client.get('/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b'id="dark-mode-toggle"', resp.data)
+
     def test_token_saved_when_remember_checked(self):
         with patch('web_app.save_token') as mock_save:
             resp = self.client.post('/', data={'token': 'abc', 'remember': 'on'})

--- a/web_app.py
+++ b/web_app.py
@@ -73,6 +73,24 @@ NAV_TEMPLATE = """
   text-align: center;
   color: #000;
 }
+body.dark-mode {
+  background-color: #222;
+  color: #eee;
+}
+body.dark-mode a {
+  color: #4dabff;
+}
+#dark-mode-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+body.dark-mode #dark-mode-toggle {
+  color: #ffda6a;
+}
 /* Table row hover effects */
 #pr-table tbody tr,
 #branch-table tbody tr {
@@ -118,6 +136,7 @@ NAV_TEMPLATE = """
 <nav class="navbar">
   <a href="{{ url_for('index') }}" class="logo">Home</a>
   <span class="nav-toggle">&#9776;</span>
+  <button id="dark-mode-toggle" aria-label="Toggle dark mode">\u263D</button>
   <div class="nav-links">
     {% if session.get('token') %}
     <a href="{{ url_for('repos') }}">Repositories</a>
@@ -152,6 +171,17 @@ document.addEventListener('DOMContentLoaded', function() {
   if (toggle && links) {
     toggle.addEventListener('click', () => {
       links.style.display = links.style.display === 'block' ? 'none' : 'block';
+    });
+  }
+  const darkToggle = document.getElementById('dark-mode-toggle');
+  if (darkToggle) {
+    const isDark = localStorage.getItem('darkMode') === 'true';
+    document.body.classList.toggle('dark-mode', isDark);
+    darkToggle.textContent = isDark ? '\u2600' : '\u263D';
+    darkToggle.addEventListener('click', () => {
+      const dark = document.body.classList.toggle('dark-mode');
+      localStorage.setItem('darkMode', dark);
+      darkToggle.textContent = dark ? '\u2600' : '\u263D';
     });
   }
 });


### PR DESCRIPTION
## Summary
- modernize UI by adding a dark mode toggle that saves the preference in local storage
- test the presence of the toggle on the index page

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e444f55c48331b15587c58ced5e7d